### PR TITLE
bugfix/remove-specific-md-filelinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="documentation/images/kubernetes-application.svg"  alt="BigBitBus KAT components" width="400"/>
 </center>
 
-**Components of the BigBitBus KAT application code. Click on the diagram to enlarge, or follow [this link](documentation/README.md) for detailed documentation**
+**Components of the BigBitBus KAT application code. Click on the diagram to enlarge, or follow [this link](documentation/) for detailed documentation**
 
 # Introduction
 
@@ -13,7 +13,7 @@ KAT is a set of software code and documentation to help understand the big pictu
 
 Most components of the Kubernates cloud native ecosystem are extremely well documented, but its hard to find end-to-end examples that illustrate how these components work together in the context of an application. The main idea is to show you the breadth of several cloud-native technologies working together to support an application deployed on Kubernetes. We provide links to high quality documentation for deep dives on the concepts our examples illustrate. Our examples will show you how it all comes together so you can get  productive, fast. You can then choose to learn more about specific parts of the cloud native stack as your situation demands.
 
-From here, we recommend you start with a [review of some Kubernetes and related concepts](./documentation/README.md) we have put together. Or, if you want to directly go to the code and examples you can navigate the folders in the repository, the table below will launch you right in.
+From here, we recommend you start with a [review of some Kubernetes and related concepts](./documentation/) we have put together. Or, if you want to directly go to the code and examples you can navigate the folders in the repository, the table below will launch you right in.
 
 ***TL;DR** If you are in a real hurry and just want to deploy the example into a local VM right now, head over to our [quickstart](./documentation/quickstart-vagrant.md).
 
@@ -23,7 +23,7 @@ From here, we recommend you start with a [review of some Kubernetes and related 
 
 | Category | File or Directory  | Description |
 |---|---|---|
-| Documentation | [documentation/README.md](./documentation/README.md) | Start here for an overview and links to other documents |
+| Documentation | [documentation/README.md](./documentation/) | Start here for an overview and links to other documents |
 | Todo Django API | [code/app-code/api/todo-python-django](code/app-code/api/todo-python-django) | Django Python todo backend; includes Helm chart deployed using Skaffold |
 | Postgresql DB | [code/k8s-common-code/postgres-db](code/k8s-common-code/postgres-db) | Installing and configuring Postgresql database into the Kubernetes cluster using Helm charts |
 | Vuejs Todo Single Page Application | [code/app-code/frontend/todo-vuejs](code/app-code/frontend/todo-vuejs) | Todo application implemented in Vuejs; includes Helm chart deployed using Skaffold |

--- a/code/app-code/frontend/todo-vuejs/README.md
+++ b/code/app-code/frontend/todo-vuejs/README.md
@@ -32,7 +32,7 @@ For this frontend to work you will need the [backend todo API](../../api/todo-py
 ### Development on your Local PC
 Developers may want to iterate through their code as they develop software on their local PC.
 
-For this frontend to work we need the API server to be online and listening at port 80. This [document](../../../app-code/api/todo-python-django/README.md) describes running the django API on the local PC directly or inside a docker container via docker-compose. Make a note of the API endpoint (e.g. localhost:8000), and export it in your terminal like so
+For this frontend to work we need the API server to be online and listening at port 80. This [document](../../../app-code/api/todo-python-django/) describes running the django API on the local PC directly or inside a docker container via docker-compose. Make a note of the API endpoint (e.g. localhost:8000), and export it in your terminal like so
 
 ```
 export VUE_APP_DJANGO_ENDPOINT=localhost:8000
@@ -51,7 +51,7 @@ Then access the frontend at [http://localhost:8080/frontend/](http://localhost:8
 
 ### Run in Kubernetes
 
-You first need to follow the steps in [this document](../../../app-code/api/todo-python-django/README.md) to get Kubernetes and the Django API running.
+You first need to follow the steps in [this document](../../../app-code/api/todo-python-django/) to get Kubernetes and the Django API running.
 
 Next, install the Vuejs helm chart, like so:
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,7 +2,7 @@
 
 **TABLE OF CONTENTS**
 
-- [BigBitBus KAT Documentation](#kubernetes-automation-toolkit-documentation)
+- [BigBitBus KAT Documentation](#bigbitbus-kat-documentation)
 - [What is in the repository?](#what-is-in-the-repository)
   - [Containers](#containers)
   - [Kubernetes](#kubernetes)
@@ -39,7 +39,7 @@ Here are some of the highlights of the KAT
 We have documented several aspects of the setup. Here is where everything is:
 | Category | File or Directory  | Description |
 |---|---|---|
-| Documentation | [README.md](./documentation/README.md) | This document. Start here for an overview and links to other documents |
+| Documentation | [README.md](./documentation/) | This document. Start here for an overview and links to other documents |
 | Todo Django API | [../code/app-code/api/todo-python-django](../code/app-code/api/todo-python-django) | Django Python todo backend and a detailed readme file; includes Helm chart deployed using Skaffold |
 | Postgresql DB | [../code/k8s-common-code/postgres-db](../code/k8s-common-code/postgres-db) | Installing and configuring Postgresql database into the Kubernetes cluster using Helm charts |
 | Vuejs Todo Single Page Application | [../code/app-code/frontend/todo-vuejs](../code/app-code/frontend/todo-vuejs) | Todo application implemented in Vuejs and a readme file; includes Helm chart deployed using Skaffold |

--- a/documentation/cloudvm.md
+++ b/documentation/cloudvm.md
@@ -36,13 +36,13 @@ ssh -i private_key_file theuser@publicip -L 8080:localhost:80 -N
 For Windows, see [this file](windows-setup.md) on how to setup Putty for port forwarding.
 
  You can now open a web-browser and reach these end-points
-  - Todo application Vuejs Frontend [http://localhost:8080/frontend/](http://localhost:8080/frontend/) [Learn more](../code/app-code/api/todo-python-django/README.md)
-  - Todo application browsable API [http://localhost:8080/djangoapi/api/v1/](http://localhost:8080/djangoapi/api/v1) [Learn more](../code/app-code/frontend/todo-vuejs/README.md)
-  - Kubernetes Dashboard [http://localhost:8080/dashboard/](http://localhost:8080/dashboard/) [Learn more](../code/k8s-common-code/k8sdashboard/README.md)
-  - Grafana Monitoring [http://localhost:8080/monitoring-grafana/](http://localhost:8080/monitoring-grafana/) [Learn more](../code/k8s-common-code/monitoring/README.md)
+  - Todo application Vuejs Frontend [http://localhost:8080/frontend/](http://localhost:8080/frontend/) [Learn more](../code/app-code/frontend/todo-vuejs/)
+  - Todo application browsable API [http://localhost:8080/djangoapi/api/v1/](http://localhost:8080/djangoapi/api/v1) [Learn more](../code/app-code/api/todo-python-django/)
+  - Kubernetes Dashboard [http://localhost:8080/dashboard/](http://localhost:8080/dashboard/) [Learn more](../code/k8s-common-code/k8sdashboard/)
+  - Grafana Monitoring [http://localhost:8080/monitoring-grafana/](http://localhost:8080/monitoring-grafana/) [Learn more](../code/k8s-common-code/monitoring/)
 
 
-3. Get the ssh-configuration snippet for your cloud VM and add it to your `~/.ssh/config` file (learn more about ssh config files [here](https://linuxize.com/post/using-the-ssh-config-file/)).
+1. Get the ssh-configuration snippet for your cloud VM and add it to your `~/.ssh/config` file (learn more about ssh config files [here](https://linuxize.com/post/using-the-ssh-config-file/)).
    
 Confirm that you can now log into the Vagrant VM by simply typing `ssh vmname-in-ssh-config` on the commandline.
 
@@ -50,7 +50,7 @@ Confirm that you can now log into the Vagrant VM by simply typing `ssh vmname-in
   - Launch [k9s from the terminal](https://k9scli.io/) and surf your Kubernetes cluster and all its objects.
   - If you prefer using the official Kubernetes CLI  then  read the `kubectl` cheat-sheet [here](https://kubernetes.io/docs/reference/kubectl/cheatsheet/).
 
-5. Head over to our [documentation](./README.md) to learn the concepts and start understanding the code behind the components..
+5. Head over to our [documentation](./) to learn the concepts and start understanding the code behind the components..
 
 ***The next steps are optional but very useful if you are planning to get productive as a developer***
 

--- a/documentation/quickstart-vagrant.md
+++ b/documentation/quickstart-vagrant.md
@@ -11,11 +11,11 @@ vagrant up
 ```
 Please be patient, even on a fast Internet connection remember we are downloading and installing over 2GB of OS, Kubernetes, docker images etc. Vagrant's output will include the `kubeconfig` for the Kubernetes cluster created within the VM, you can use the security token below to connect to the [Kubernetes dashboard](../k8s-common-code/k8sdashboard/).
 
-3.  You can now open a web-browser and reach these end-points
-  - Todo application Vuejs Frontend [http://localhost:8080/frontend/](http://localhost:8080/frontend/) [Learn more](../code/app-code/api/todo-python-django/README.md)
-  - Todo application browsable API [http://localhost:8080/djangoapi/api/v1/](http://localhost:8080/djangoapi/api/v1) [Learn more](../code/app-code/frontend/todo-vuejs/README.md)
-  - Kubernetes Dashboard [http://localhost:8080/dashboard/](http://localhost:8080/dashboard/) [Learn more](../code/k8s-common-code/k8sdashboard/README.md)
-  - Grafana Monitoring [http://localhost:8080/monitoring-grafana/](http://localhost:8080/monitoring-grafana/) [Learn more](../code/k8s-common-code/monitoring/README.md)
+3.   You can now open a web-browser and reach these end-points
+  - Todo application Vuejs Frontend [http://localhost:8080/frontend/](http://localhost:8080/frontend/) [Learn more](../code/app-code/frontend/todo-vuejs/)
+  - Todo application browsable API [http://localhost:8080/djangoapi/api/v1/](http://localhost:8080/djangoapi/api/v1) [Learn more](../code/app-code/api/todo-python-django/)
+  - Kubernetes Dashboard [http://localhost:8080/dashboard/](http://localhost:8080/dashboard/) [Learn more](../code/k8s-common-code/k8sdashboard/)
+  - Grafana Monitoring [http://localhost:8080/monitoring-grafana/](http://localhost:8080/monitoring-grafana/) [Learn more](../code/k8s-common-code/monitoring/)
 
 
 4. Get the ssh-configuration snippet for your Vagrant VM and add it to your `~/.ssh/config` file; these commands will do this:


### PR DESCRIPTION
Instead of pointing to the markdown files, we point to the directory with the readme file so that the file browser is also seen.